### PR TITLE
Format main.go using standard Go conventions

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"os"
-	"html"
 
 	log "github.com/sirupsen/logrus"
 )


### PR DESCRIPTION
Looks like main.go was last edited with an editor that did not automatically apply `gofmt -s` on save. Go Report Card flagged this as an inconsistency.