### PR TITLE
Removing unnecessary variables/config

### DIFF
--- a/etc/manifests/frontend.yml
+++ b/etc/manifests/frontend.yml
@@ -3,8 +3,4 @@ applications:
   path: ../../html
   memory: 64M
   domain: app.cloud.gov
-  host: revampd
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
-  env:
-    FORCE_HTTPS: true
-    API_BASE_URL: https://revampd-api.app.cloud.gov


### PR DESCRIPTION
FORCE_HTTPS - not necessary since HSTS added to all cloud.gov apps in 2015
API_BASE_URL - not used... yet
host - not necessary since we are OK with it being the same as the app name.