### PR TITLE
Add local and cloud.gov PostgreSQL instance

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,18 @@
 # TCP port that the API backend listens on inside the container.
-# Local stand-in for Cloud Foundry PORT (see: https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#PORT).
+# Local stand-in for Cloud Foundry PORT. See:
+# https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#PORT
+# https://cloud.gov/docs/apps/troubleshooting/#environment-variables-and-service-bindings
 PORT=2019
+
+# PostgreSQL connection string used by the API backend.
+# Local stand-in for Cloud Foundry DATABASE_URL. See:
+# https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#DATABASE-URL
+# https://cloud.gov/docs/services/relational-database/
+#
+# The host is `db`, the service defined docker-compose.yml.
+# The user and database is `postgres`, set up by the stock
+# PostgreSQL Docker Hub image - no password is set.
+# As this is just for local development, the standard guidance
+# to not use this superuser account/database does not apply.
+# Likewise, the guidance against unencrypted connections.
+DATABASE_URL=postgres://postgres@db:5432/postgres?sslmode=disable

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker-compose up --abort-on-container-exit --build
 
 Log messages will be printed to the console's `stdout`.
 
-Once the `revampd_web_1` and `revampd_api_1` instances have started up, a web browser can be directed to `http://localhost:9080` to access the frontend. The API backend can be access directly at `http://localhost:8080`.
+Once the `revampd_web_1`, `revampd_db_1`, and `revampd_api_1` instances have started up, a web browser can be directed to `http://localhost:9080` to access the frontend. The API backend can be access directly at `http://localhost:8080`.
 
 ### Stopping and cleaning up the local server
 

--- a/bin/setup-cloudgov
+++ b/bin/setup-cloudgov
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Run once after space creation, before any apps are pushed.
+
+set -e
+
+CF_ORG="epa-prototyping"
+CF_SPACE="dev-ampd"
+DB_NAME="revampd-psql" # bound to app in etc/manifests/api.yml
+
+cf target -o $CF_ORG -s $CF_SPACE
+
+# The shared-psql service instance is for prototype environments only;
+# it is a shared database, does not have backups, is not for
+# sensitive/production data, but does not incur additional costs.
+# This service instance type uses AWS RDS 9.4.x.
+# For more details see:
+# https://cloud.gov/docs/services/relational-database/
+cf create-service aws-rds shared-psql $DB_NAME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     ports:
       # map port 8080 on the host OS to the port defined in .env
       - "8080:${PORT}"
+    depends_on:
+      - db
   
   # Endpoint for the frontend, serving static assets.
   # Local stand-in for the staticfile buildpack in Cloud Foundry (see: etc/manifests/frontend.yml).
@@ -40,3 +42,11 @@ services:
     ports:
       # Stock container listens on port 80 
       - "9080:80"
+
+  # Endpoint for the PostgreSQL relational database used by the API backend.
+  # Local stand-in for the Cloud Foundry service instance named `revampd-psql`
+  # (see: bin/setup-cloudgov).
+  db:
+    image: postgres:9.4
+    ports:
+      - "5432:5432"

--- a/etc/manifests/api.yml
+++ b/etc/manifests/api.yml
@@ -6,6 +6,9 @@ applications:
   stack: cflinuxfs3
   buildpacks:
   - go_buildpack
+  services:
+  # defined in bin/setup-cloudgov
+  - revampd-psql
   env:
     GOVERSION: go1.12
     GOPACKAGENAME: github.com/18F/revampd

--- a/src/Gopkg.lock
+++ b/src/Gopkg.lock
@@ -2,12 +2,35 @@
 
 
 [[projects]]
+  digest = "1:6c41d4f998a03b6604227ccad36edaed6126c397e5d78709ef4814a1145a6757"
+  name = "github.com/jmoiron/sqlx"
+  packages = [
+    ".",
+    "reflectx",
+  ]
+  pruneopts = "UT"
+  revision = "d161d7a76b5661016ad0b085869f77fd410f3e6a"
+  version = "v1.2.0"
+
+[[projects]]
   digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
   pruneopts = "UT"
   revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
   version = "v1.0.2"
+
+[[projects]]
+  digest = "1:12cb143f2148bf54bcd9fe622abac17325e85eeb1d84b8ec6caf1c80232108fd"
+  name = "github.com/lib/pq"
+  packages = [
+    ".",
+    "oid",
+    "scram",
+  ]
+  pruneopts = "UT"
+  revision = "3427c32cb71afc948325f299f040e53c1dd78979"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
@@ -28,6 +51,10 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = ["github.com/sirupsen/logrus"]
+  input-imports = [
+    "github.com/jmoiron/sqlx",
+    "github.com/lib/pq",
+    "github.com/sirupsen/logrus",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/src/main.go
+++ b/src/main.go
@@ -7,12 +7,29 @@ import (
 	"os"
 	"regexp"
 
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
 	log "github.com/sirupsen/logrus"
 )
 
 func init() {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.DebugLevel)
+}
+
+func getPostgreSQLVersion() (string, error) {
+	db, err := sqlx.Connect("postgres", os.Getenv("DATABASE_URL"))
+	if err != nil {
+		return "", err
+	}
+
+	rows := []string{}
+	err = db.Select(&rows, "SELECT version()")
+	if err != nil {
+		return "", err
+	}
+
+	return rows[0], nil
 }
 
 func helloHtml(path string) string {
@@ -30,6 +47,13 @@ func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, helloHtml(r.URL.Path))
 	})
+
+	version, err := getPostgreSQLVersion()
+	if err != nil {
+		log.Error(err)
+	} else {
+		log.Debug(version)
+	}
 
 	log.Debug("Starting revAMPD API backend, listening on port " + os.Getenv("PORT"))
 	http.ListenAndServe(":"+os.Getenv("PORT"), nil)


### PR DESCRIPTION
- Add local PostgreSQL instance and script that sets up RDS on cloud.gov.
- At API backend start up, connect to the database and log its version.